### PR TITLE
Rebuild for Arb 2.17

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,3 +1,5 @@
+arb:
+- '2.17'
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,5 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+arb:
+- '2.17'
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 9
+  number: 10
   skip: True  # [win]
   detect_binary_files_with_prefix: True
   run_exports:


### PR DESCRIPTION
A new version of Arb has been released and we are changing all the pins in conda-forge to that latest version 2.17. The pin is set globally in https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml#L355